### PR TITLE
Support parsing IPv6 addresses with embedded IPv4 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ const ipv6 = parseIP("2001:db8::1");
 console.log(ipv4.version); // 4
 console.log(ipv6.version); // 6
 
+// parseIP supports IPv6 addresses with embedded IPv4 addresses
+const ipv6embed = parseIP("2001:db8::192.0.2.1");
+console.log(ipv6.version); // 6
+
 // Address objects implement the toString method for turning the addresses back
 // into strings. The strings are printed lower-cased sans any  extra leading
 // zeroes. IPv6 formatting follows the RFC 5952
-// (https://tools.ietf.org/html/rfc5952) recommendations.
+// (https://tools.ietf.org/html/rfc5952) recommendations, except that
+// Formatting doesn't output IPv6 addresses with embedded IPv4 addresses.
 console.log(String(ipv4)); // 192.0.2.1
 console.log(String(ipv6)); // 2001:db8::1
+console.log(String(ipv6embed)); // 2001:db8::c000:201
 
 // Method cmp(...) can be used to compare and sort addresses, and a.cmp(b)
 // returns:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "keywords": [
     "ip",
+    "ipv4",
+    "ipv6",
+    "rfc4291",
     "rfc5952"
   ]
 }

--- a/test/ipv46.test.js
+++ b/test/ipv46.test.js
@@ -168,6 +168,46 @@ describe("IPv6", () => {
             const b = parseIP("1:0:3:4:5:6:7:8");
             expect(a.cmp(b)).toBe(0);
         });
+        it("accepts embedded IPv4 addresses after prefix 0:0:0:0:0:0", () => {
+            const a = parseIP("::192.0.2.1");
+            const b = parseIP("::c000:201");
+            expect(a.cmp(b)).toBe(0);
+        });
+        it("accepts embedded IPv4 addresses after prefix 0:0:0:0:0:ffff", () => {
+            const a = parseIP("::ffff:192.0.2.1");
+            const b = parseIP("::ffff:c000:201");
+            expect(a.cmp(b)).toBe(0);
+        });
+        it("accepts embedded IPv4 addresses after any 96-bit prefix", () => {
+            const a = parseIP("2001:db8::192.0.2.1");
+            const b = parseIP("2001:db8::c000:201");
+            expect(a.cmp(b)).toBe(0);
+        });
+        it("doesn't interpret a single trailing number between 0-255 as an octet", () => {
+            const a = parseIP("2001:db8::1ff");
+            const b = parseIP("2001:db8::255");
+            expect(a.cmp(b)).toBe(-1);
+        });
+        it("requires embedded IPv4 addresses to be well-formed", () => {
+            expect(parseIP("2001:db8::192.0.2.256")).toBeNull();
+            expect(parseIP("2001:db8::192.0.2.1.0")).toBeNull();
+            expect(parseIP("2001:db8::192.0.2")).toBeNull();
+            expect(parseIP("2001:db8::192.0")).toBeNull();
+            expect(parseIP("2001:db8::192.0.2.")).toBeNull();
+            expect(parseIP("2001:db8::.0.2.1")).toBeNull();
+        });
+        it("counts embedded IPv4 address as 2 words", () => {
+            expect(parseIP("1:2:3:4:5:6:7:8:192.0.2.1")).toBeNull();
+            expect(parseIP("1:2:3:4:5:6:7:192.0.2.1")).toBeNull();
+        });
+        it("disallows non-trailing IPv4 addresses", () => {
+            expect(parseIP("192.0.2.1::")).toBeNull();
+            expect(parseIP("0:192.0.2.1::")).toBeNull();
+            expect(parseIP("0:0:192.0.2.1::")).toBeNull();
+            expect(parseIP("::192.0.2.1:0:0:0")).toBeNull();
+            expect(parseIP("::192.0.2.1:0:0")).toBeNull();
+            expect(parseIP("::192.0.2.1:0")).toBeNull();
+        });
     });
 
     describe("formatting", () => {

--- a/test/ipv46.test.js
+++ b/test/ipv46.test.js
@@ -242,6 +242,11 @@ describe("IPv6", () => {
             expect(String(parseIP("abcd:ef00::"))).toBe("abcd:ef00::");
             expect(String(parseIP("ABCD:EF00::"))).toBe("abcd:ef00::");
         });
+        it("doesn't output embedded IPv4 addresses", () => {
+            expect(String(parseIP("::192.0.2.1"))).toBe("::c000:201");
+            expect(String(parseIP("::ffff:192.0.2.1"))).toBe("::ffff:c000:201");
+            expect(String(parseIP("2001:db8::192.0.2.1"))).toBe("2001:db8::c000:201");
+        });
     });
 });
 


### PR DESCRIPTION
This pull request adds support for parsing IPv6 addresses with embedded IPv4. The format is outlined in [RFC 4291 section 2.2](https://tools.ietf.org/html/rfc4291#section-2.2). An IPv4 address following *any* 96-bit IPv6 prefix is supported - it's not limited to e.g. prefixes `::` or `::ffff`.

IPv6 address formatting doesn't change and therefore doesn't ever output IPv6 strings with embedded IPv4 addresses. This is still compatible with [RFC 5952 section 5](https://tools.ietf.org/html/rfc5952#section-5), which only recommends the mixed notation for well-known prefixes.